### PR TITLE
fix(capstone): correct grasp frame rotation

### DIFF
--- a/matlab/Modern Robotics Homework/Course 6/Capstone Project/Capstone_Current/runSimulation.m
+++ b/matlab/Modern Robotics Homework/Course 6/Capstone Project/Capstone_Current/runSimulation.m
@@ -40,12 +40,16 @@ else
 end
 
 %% Define grasp configurations
-% Vertical approach using a 90-degree rotation about the y-axis
-R_y = [0, 0, 1;
-       0, 1, 0;
-      -1, 0, 0];
+% Approach frame tilted about y by 36 degrees to match reference project
+a = pi/5;  % [rad] tilt angle from functional project specification
+% Rotation matrix for end-effector approach relative to cube frame
+R_y = [-sin(a), 0,  cos(a);
+       0,       1,  0;
+      -cos(a), 0, -sin(a)];
+
+% Grasp and standoff expressed relative to the cube frame
 Tce_grasp = RpToTrans(R_y, [0; 0; 0]);
-Tce_standoff = RpToTrans(R_y, [0; 0; 0.15]);
+Tce_standoff = RpToTrans(R_y, [0; 0; 0.25]);
 
 % Precompute world-frame configurations
 Tse_standoff_initial = Tsc_initial * Tce_standoff;

--- a/matlab/Modern Robotics Homework/Course 6/Capstone Project/Capstone_Current/runSimulation.m
+++ b/matlab/Modern Robotics Homework/Course 6/Capstone Project/Capstone_Current/runSimulation.m
@@ -40,12 +40,12 @@ else
 end
 
 %% Define grasp configurations
-% Approach frame tilted about y by 36 degrees to match reference project
-a = pi/5;  % [rad] tilt angle from functional project specification
-% Rotation matrix for end-effector approach relative to cube frame
-R_y = [-sin(a), 0,  cos(a);
-       0,       1,  0;
-      -cos(a), 0, -sin(a)];
+% Approach frame rotated about y by 36 degrees (pi/5)
+a = pi/5;  % [rad] rotation angle about y
+% Rotation matrix for a right-handed rotation about the y-axis by angle a
+R_y = [cos(a), 0,  sin(a);
+       0,      1,  0;
+      -sin(a), 0,  cos(a)];
 
 % Grasp and standoff expressed relative to the cube frame
 Tce_grasp = RpToTrans(R_y, [0; 0; 0]);


### PR DESCRIPTION
## Changes
- correct end-effector approach rotation in `runSimulation.m` to match reference project

## Verification
- `python quality_check_script.py`

------
https://chatgpt.com/codex/tasks/task_e_68994ca4a8c083208811b156f2271a3e